### PR TITLE
bump native to 1.18.2.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Updated `OpenZiti.NET.native` dependency from 1.10.4.213 to 1.16.0.243 (ziti-sdk-c 1.16.0).
+- Updated `OpenZiti.NET.native` dependency from 1.10.4.213 to 1.18.2.49 (ziti-sdk-c 1.18.2).
 - **BREAKING (low-level interop only)**: re-laid the `OpenZiti.Native` model structs and event types to match the
   ziti-sdk-c 1.16 ABI. `model_number`-backed fields are now `long`, the event model is restructured (no leading
   event-type field on the union sub-structs; `ZitiMfaAuthEvent`→`ZitiAuthEvent`, `ZitiAPIEvent`→`ZitiConfigEvent`),

--- a/OpenZiti.NET.Samples/src/Kestrel/KestrelSampleClient.cs
+++ b/OpenZiti.NET.Samples/src/Kestrel/KestrelSampleClient.cs
@@ -25,7 +25,7 @@ public class KestrelClientSample : SampleBase {
         var client = new HttpClient(new Debugging.LoggingHandler(zitiSocketHandler));
         client.DefaultRequestHeaders.Add("User-Agent", "curl/7.59.0");
 
-        var result = client.GetStringAsync(args[0]).Result;
+        var result = await client.GetStringAsync(args[0]);
         Log.Info("result: {}", result);
 
         return result;

--- a/OpenZiti.NET.Samples/src/Kestrel/ZitiConnectionListenerFactory.cs
+++ b/OpenZiti.NET.Samples/src/Kestrel/ZitiConnectionListenerFactory.cs
@@ -52,7 +52,6 @@ internal class ZitiConnectionListenerFactory : IConnectionListenerFactory {
     private class ZitiSocketListener : IConnectionListener {
         private readonly ZitiSocket _zitiSocket;
         private readonly ZitiContext _zitiContext;  // Keep context alive
-        private readonly Socket _socket;
         private readonly ILogger _logger;
         private readonly SocketConnectionContextFactory _contextFactory;
         private readonly Channel<(ZitiSocket socket, string caller)> _connectionChannel;
@@ -63,7 +62,6 @@ internal class ZitiConnectionListenerFactory : IConnectionListenerFactory {
         public ZitiSocketListener(ZitiSocket zitiSocket, ZitiContext zitiContext, ILogger logger) {
             _zitiSocket = zitiSocket;
             _zitiContext = zitiContext;  // Keep reference to prevent GC
-            _socket = zitiSocket.ToSocket();
             _logger = logger;
             _contextFactory = new SocketConnectionContextFactory(new SocketConnectionFactoryOptions(), logger);
 
@@ -82,55 +80,25 @@ internal class ZitiConnectionListenerFactory : IConnectionListenerFactory {
             _logger.LogInformation("Started dedicated Ziti accept loop");
         }
 
-        public EndPoint EndPoint => _socket.LocalEndPoint ?? new IPEndPoint(IPAddress.Any, 0);
+        public EndPoint EndPoint => new IPEndPoint(IPAddress.Any, 0);
 
         /// <summary>
-        /// Background thread that uses non-blocking accept with select/poll
-        /// to allow periodic cancellation checks
+        /// Dedicated thread that blocks in API.Accept for each Ziti client and queues it for Kestrel.
+        /// UnbindAsync closes the listening socket to unblock the pending accept on shutdown.
         /// </summary>
         private async Task AcceptLoopAsync() {
             _logger.LogInformation("Ziti accept loop starting");
-
             try {
-                // Set socket to non-blocking mode
-                _socket.Blocking = false;
-                _logger.LogInformation("Socket set to non-blocking mode");
-
                 while (!_acceptLoopCts.Token.IsCancellationRequested) {
+                    ZitiSocket client;
+                    string caller;
                     try {
-                        // Poll with timeout to check if socket is readable (connection waiting)
-                        // Using 1 second timeout so we can check cancellation frequently
-                        _logger.LogDebug("Polling for Ziti connection...");
-                        bool ready = _socket.Poll(1_000_000, SelectMode.SelectRead); // 1 second in microseconds
-
-                        if (!ready) {
-                            // Timeout - no connection available, loop again and check cancellation
-                            continue;
-                        }
-
-                        // Socket is readable - accept should not block
-                        _logger.LogDebug("Socket ready, calling Accept...");
-                        var client = API.Accept(_zitiSocket, out var caller);
-                        _logger.LogInformation("Accepted connection from Ziti client: {Caller}", caller ?? "unknown");
-
-                        // Push to channel for Kestrel to consume asynchronously
-                        await _connectionChannel.Writer.WriteAsync((client, caller ?? "unknown"), _acceptLoopCts.Token);
-                        _logger.LogDebug("Connection queued for processing");
-
-                    } catch (SocketException ex) when (ex.SocketErrorCode == SocketError.WouldBlock && !_disposed) {
-                        // Non-blocking accept returned EWOULDBLOCK - try again
-                        _logger.LogDebug("Accept would block, retrying...");
-                        continue;
-                    } catch (SocketException ex) when (!_disposed) {
-                        _logger.LogError(ex, "Socket error in accept loop: {ErrorCode}", ex.SocketErrorCode);
-                        // Continue accepting, transient error
-                    } catch (ObjectDisposedException) {
-                        _logger.LogDebug("Socket disposed, exiting accept loop");
-                        break;
-                    } catch (Exception ex) when (!_disposed) {
-                        _logger.LogError(ex, "Unexpected error in accept loop");
-                        // Continue accepting
+                        client = API.Accept(_zitiSocket, out caller);
+                    } catch (Exception) when (_acceptLoopCts.Token.IsCancellationRequested || _disposed) {
+                        break; // listener closed on shutdown -> accept unblocked with an error
                     }
+                    _logger.LogInformation("Accepted connection from Ziti client: {Caller}", caller ?? "unknown");
+                    await _connectionChannel.Writer.WriteAsync((client, caller ?? "unknown"), _acceptLoopCts.Token);
                 }
             } finally {
                 _connectionChannel.Writer.Complete();
@@ -213,7 +181,8 @@ internal class ZitiConnectionListenerFactory : IConnectionListenerFactory {
                     }
                 }
 
-                _socket?.Dispose();
+                // The listener fd was already closed by UnbindAsync (which unblocks the accept); do not
+                // close it again here (avoids a double Ziti_close on the same handle).
                 _acceptLoopCts?.Dispose();
 
             } catch (Exception ex) {

--- a/OpenZiti.NET.Samples/src/Server/HostedServiceSample.cs
+++ b/OpenZiti.NET.Samples/src/Server/HostedServiceSample.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 using OpenZiti.NET.Samples.Common;
@@ -38,26 +39,33 @@ namespace OpenZiti.NET.Samples.Server {
             API.Bind(socket, ctx, svcName, terminator);
             API.Listen(socket, 100);
 
-            Log.Info("Beginning accept loop...");
-            while (true) {
-                ZitiSocket client = API.Accept(socket, out var caller);
-                using (var s = client.ToNetworkStream())
-                using (var r = new StreamReader(s))
-                using (var w = new StreamWriter(s)) {
-                    w.AutoFlush = true;
-                    Log.Info($"receiving connection from {caller}");
-                    string read = await r.ReadLineAsync();
-                    while (read != "EOL") {
-                        Log.Info($"{caller} sent {read}");
-                        string resp = $"Hi {caller}. Thanks for sending me: {read}";
-                        await w.WriteLineAsync(resp);
-                        Log.Info($"replied to {caller}");
-                        read = r.ReadLine();
+            // Cancelling the token closes the listener and unblocks AcceptAsync (Ctrl-C for graceful shutdown).
+            using var cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+
+            Log.Info("Beginning async accept loop (Ctrl-C to stop)...");
+            try {
+                while (!cts.Token.IsCancellationRequested) {
+                    ZitiSocket client = await API.AcceptAsync(socket, cts.Token);
+                    using (var s = client.ToNetworkStream())
+                    using (var r = new StreamReader(s))
+                    using (var w = new StreamWriter(s)) {
+                        w.AutoFlush = true;
+                        Log.Info($"receiving connection from {client.Caller}");
+                        string read = await r.ReadLineAsync();
+                        while (read != null && read != "EOL") {
+                            Log.Info($"{client.Caller} sent {read}");
+                            await w.WriteLineAsync($"Hi {client.Caller}. Thanks for sending me: {read}");
+                            read = await r.ReadLineAsync();
+                        }
+                        await w.WriteLineAsync("disconnecting...");
+                        Log.Info($"{client.Caller} disconnected");
                     }
-                    await w.WriteLineAsync("disconnecting...");
-                    Log.Info($"{caller} disconnected");
                 }
+            } catch (OperationCanceledException) {
+                Log.Info("accept loop cancelled; shutting down");
             }
+            return null;
         }
     }
 }

--- a/OpenZiti.NET.Samples/src/Weather/WeatherSample.cs
+++ b/OpenZiti.NET.Samples/src/Weather/WeatherSample.cs
@@ -41,7 +41,7 @@ namespace OpenZiti.NET.Samples.Weather {
             var client = new HttpClient(new Debugging.LoggingHandler(zitiSocketHandler));
             client.DefaultRequestHeaders.Add("User-Agent", "curl/7.59.0");
 
-            var result = client.GetStringAsync("https://wttr.in:443").Result;
+            var result = await client.GetStringAsync("https://wttr.in:443");
             Console.Write(result);
             return result;
         }

--- a/OpenZiti.NET.Tests/OpenZiti.NET.Tests.csproj
+++ b/OpenZiti.NET.Tests/OpenZiti.NET.Tests.csproj
@@ -39,7 +39,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenZiti.NET.native" Version="1.16.0.245" />
+    <PackageReference Include="OpenZiti.NET.native" Version="1.18.2.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenZiti.NET/OpenZiti.NET.csproj
+++ b/OpenZiti.NET/OpenZiti.NET.csproj
@@ -54,7 +54,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2" />
         <PackageReference Include="NLog" Version="6.0.7" />
-        <PackageReference Include="OpenZiti.NET.native" Version="1.16.0.245" />
+        <PackageReference Include="OpenZiti.NET.native" Version="1.18.2.49" />
         <PackageReference Include="System.Memory" Version="4.6.3" />
         <PackageReference Include="System.Text.Json" Version="10.0.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/OpenZiti.NET/OpenZiti.NET.nuspec
+++ b/OpenZiti.NET/OpenZiti.NET.nuspec
@@ -22,7 +22,7 @@
         <dependency id="Microsoft.Extensions.Logging" version="10.0.2" exclude="Build,Analyzers" xmlns="" />
         <dependency id="Newtonsoft.Json" version="13.0.4" exclude="Build,Analyzers" xmlns="" />
         <dependency id="NLog" version="6.0.7" exclude="Build,Analyzers" xmlns="" />
-        <dependency id="OpenZiti.NET.native" version="1.16.0.245" exclude="Build,Analyzers" xmlns="" />
+        <dependency id="OpenZiti.NET.native" version="1.18.2.49" exclude="Build,Analyzers" xmlns="" />
         <dependency id="System.Memory" version="4.6.3" exclude="Build,Analyzers" xmlns="" />
         <dependency id="System.Text.Json" version="10.0.2" exclude="Build,Analyzers" xmlns="" />
       </group>

--- a/OpenZiti.NET/src/OpenZiti/Native/structs.cs
+++ b/OpenZiti.NET/src/OpenZiti/Native/structs.cs
@@ -250,6 +250,13 @@ namespace OpenZiti.Native {
         ziti_enroll_token,
     }
 
+    public enum ziti_crypto_method {
+        ziti_crypto_invalid = -1,
+        ziti_crypto_none = 0,
+        ziti_crypto_libsodium,
+        ziti_crypto_aes_gcm,
+    }
+
     // 1.16: ziti_options no longer carries `config` or `router_keepalive`; it gained
     // `cert_extension_window` and `enroll_mode`. NOTE the C `long refresh_interval` is 4 bytes on
     // Windows (LLP64) but 8 bytes on Linux/macOS (LP64). This managed layout matches Windows, which
@@ -258,6 +265,7 @@ namespace OpenZiti.Native {
     public struct ziti_options {
         [MarshalAs(UnmanagedType.I1)] public bool disabled;
         public IntPtr /*public char**/ config_types;
+        public ziti_crypto_method e2ee_mode; //end-to-end encryption mode
         public uint api_page_size;
         public uint refresh_interval; //C `long`: seconds between controller refreshes (see note above re: width)
         public ziti_metric_type metrics_type; //an enum describing the metrics to collect

--- a/native/e2e-app/e2e-app.csproj
+++ b/native/e2e-app/e2e-app.csproj
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <!-- which native build to test; CI passes the fresh one -->
-    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.16.0.245</ZitiNativeVersion>
+    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.2.49</ZitiNativeVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/native/e2e/E2ETest.csproj
+++ b/native/e2e/E2ETest.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <!-- which native build to test; CI passes the fresh one -->
-    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.16.0.245</ZitiNativeVersion>
+    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.2.49</ZitiNativeVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/native/smoke-test/SmokeTest.csproj
+++ b/native/smoke-test/SmokeTest.csproj
@@ -19,7 +19,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <!-- Fallback only for ad-hoc local runs; CI always passes -p:ZitiNativeVersion=... -->
-    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.16.0.245</ZitiNativeVersion>
+    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.2.49</ZitiNativeVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
point managed SDK at OpenZiti.NET.native 1.18.2.49 (ziti-sdk-c 1.18.2); adapt samples