### PR TITLE
publish pre-releases too

### DIFF
--- a/.github/workflows/native-nuget-publish.yml
+++ b/.github/workflows/native-nuget-publish.yml
@@ -1,7 +1,7 @@
 name: Matrix Build and publish Ziti Native to nuget
 
 on:
-  # Nightly: resolve the latest ziti-sdk-c release and publish it if nuget.org doesn't have it yet.
+  # Nightly: build the newest ziti-sdk-c release (prereleases included) and push it if nuget.org lacks it.
   schedule:
     # 04:17 UTC nightly (off the top of the hour to dodge cron congestion).
     - cron: '17 4 * * *'
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Full package version to publish, e.g. 1.18.2.50 (<ziti-sdk-c version>.<revision>). Leave blank to publish the latest ziti-sdk-c release automatically.
+        description: Full package version to publish, e.g. 1.18.2.50 (<ziti-sdk-c version>.<revision>), optionally with a prerelease label (1.18.7.50-preview). Leave blank to publish the newest ziti-sdk-c release automatically.
         default: ''
         required: false
       debugOrRelease:
@@ -22,7 +22,7 @@ on:
         type: boolean
         default: false
       force:
-        description: Publish even if this version's base is already on nuget.org
+        description: Publish even if this version's base + channel (stable/preview) is already on nuget.org
         type: boolean
         default: false
 
@@ -39,17 +39,22 @@ permissions:
   contents: read
 
 jobs:
-  # Decide what to publish and whether to publish at all. Two paths:
+  # Decide what to build and whether to push it. Two paths:
   #  - version input given (manual explicit): publish exactly that full <csdk>.<revision>.
-  #  - version input blank (nightly cron, or manual "publish latest"): resolve the latest ziti-sdk-c release and
-  #    publish it as <csdk>.<run_number> if nuget doesn't already have that base.
-  # check-and-publish-native.ps1 dedups on the 3-part base, so republishing a new revision of an already-published
-  # csdk base (e.g. 1.18.2.50 when 1.18.2.x exists) needs -Force.
+  #  - version input blank (nightly cron, or manual "publish latest"): resolve the newest ziti-sdk-c release,
+  #    PRERELEASES INCLUDED, and publish it as <csdk>.<run_number>, suffixed "-preview" when csdk marks that
+  #    release as a prerelease.
+  # check-and-publish-native.ps1 dedups on the 3-part csdk base plus the channel (stable or preview), so the
+  # run number never matters, a csdk prerelease publishes once, and the same base publishes again as stable
+  # when csdk promotes it. Republishing a new revision of an already-published base+channel needs -Force.
   resolve:
     runs-on: ubuntu-latest
     outputs:
       shouldPublish: ${{ steps.check.outputs.shouldPublish }}
+      # csdk: the 3-part csdk version (the git tag to build, and the base of the package version).
+      # channel: stable | preview, mirroring whether the csdk release is marked as a prerelease.
       csdk: ${{ steps.norm.outputs.csdk }}
+      channel: ${{ steps.check.outputs.channel }}
       version: ${{ steps.norm.outputs.version }}
     steps:
       - uses: actions/checkout@v5
@@ -69,15 +74,23 @@ jobs:
       - name: Resolve full package version + csdk build tag
         id: norm
         run: |
-          csdk="${{ steps.check.outputs.baseVersion }}"
           if [ -n "${{ inputs.version }}" ]; then
+            # Explicit path: the caller named the full package version. There is no csdk release to consult,
+            # so the build tag is that version's 3-part base.
+            csdk="${{ steps.check.outputs.baseVersion }}"
             full="${{ inputs.version }}"
           else
-            # Automated path: the latest csdk tag plus this run's number as the revision (e.g. 1.19.0.42).
-            full="${{ steps.check.outputs.version }}.${{ github.run_number }}"
+            # Automated path: the newest csdk release's tag, plus this run's number as the revision
+            # (e.g. 1.19.0.42). A csdk prerelease ships as a nuget prerelease so it can never be mistaken
+            # for a released native, and so the same base can publish again as stable once csdk promotes it.
+            csdk="${{ steps.check.outputs.version }}"
+            full="${{ steps.check.outputs.baseVersion }}.${{ github.run_number }}"
+            if [ "${{ steps.check.outputs.channel }}" = "preview" ]; then
+              full="$full-preview"
+            fi
           fi
-          if ! echo "$full" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::resolved version '$full' is not <ziti-sdk-c version>.<revision>, e.g. 1.18.2.50"
+          if ! echo "$full" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::resolved version '$full' is not <ziti-sdk-c version>.<revision>[-label], e.g. 1.18.2.50 or 1.18.7.50-preview"
             exit 1
           fi
           echo "csdk=$csdk" >> "$GITHUB_OUTPUT"
@@ -89,7 +102,7 @@ jobs:
   # vcpkg.json) + RID, not the ziti version, so versions sharing a baseline reuse one cache.
   ensure-cache-release:
     needs: [resolve]
-    if: needs.resolve.outputs.shouldPublish == 'true' && github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -103,8 +116,9 @@ jobs:
 
   native-matrix-build:
     needs: [resolve, ensure-cache-release]
-    # Skip everything when already published (resolve) or when triggered by dependabot.
-    if: needs.resolve.outputs.shouldPublish == 'true' && github.actor != 'dependabot[bot]'
+    # Build on every run, even when nothing will be pushed: a nightly build+gate is how a csdk or shim
+    # break gets found the night it happens instead of on release day. Only 'publish' gates on shouldPublish.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -413,9 +427,11 @@ jobs:
   # transient plumbing for the managed SDK, so it gets a lightweight git tag (to find the commit behind a nuget
   # version) but NO GitHub Release. Releases live on the idiomatic OpenZiti.NET package.
   publish:
-    needs: [create-nuget-package, smoke-test, e2e-test]
-    # Push only from the canonical repo, and never on a dry run.
-    if: ${{ github.repository == 'openziti/ziti-sdk-csharp' && inputs.dryRun != true }}
+    needs: [resolve, create-nuget-package, smoke-test, e2e-test]
+    # Push only from the canonical repo, never on a dry run, and only when this csdk version + channel is not
+    # already on nuget.org. The build and both gates above ran regardless; this is the only job that cares
+    # whether there is something new to ship.
+    if: ${{ github.repository == 'openziti/ziti-sdk-csharp' && inputs.dryRun != true && needs.resolve.outputs.shouldPublish == 'true' }}
     runs-on: windows-2022
     # Overrides the top-level contents:read so the tag step can push the tag.
     permissions:

--- a/scripts/check-and-publish-native.ps1
+++ b/scripts/check-and-publish-native.ps1
@@ -6,16 +6,21 @@
 .DESCRIPTION
     Decides whether a ziti-sdk-c version still needs to be published to nuget.org as OpenZiti.NET.native.
     Two modes:
-      - Default (no -Version): resolves the latest ziti-sdk-c release tag and checks that one. Used by the
-        nightly job.
+      - Default (no -Version): resolves the newest ziti-sdk-c release, PRERELEASES INCLUDED, and checks that
+        one. Used by the nightly job. A csdk prerelease ships as a nuget prerelease ("-preview").
       - -Version <tag>: checks that one specific tag. Used as the pre-flight guard inside the publish
-        workflow so an already-published version just skips instead of double-publishing.
+        workflow so an already-published version just skips instead of double-publishing. A "-" label in
+        the version (e.g. 1.18.7.50-preview) marks it as the preview channel.
 
-    Comparison is on the 3-part base version (the published nuget version is "<base>.<run_number>", e.g.
-    1.16.0.213, so 1.16.0 counts as "1.16.0 published").
+    Comparison is on the 3-part base version PLUS the channel (stable or preview). The published nuget
+    version is "<base>.<run_number>" with an optional "-preview" suffix, e.g. 1.16.0.213 or
+    1.16.0.213-preview, so the run number never affects the decision. Carrying the channel in the key is
+    what lets a csdk release publish once as a preview and then again, correctly, as stable when csdk
+    promotes it.
 
     Prints a human-readable summary. When running inside GitHub Actions ($env:GITHUB_OUTPUT is set), also
-    writes 'shouldPublish', 'version', and 'baseVersion' outputs so a downstream job can gate on them.
+    writes 'shouldPublish', 'version', 'baseVersion', and 'channel' outputs so a downstream job can gate
+    on them.
 
     No hardcoded secrets or run-specific values: every external input is a parameter, so this script can be
     run by hand for an ad-hoc check or backfill.
@@ -57,6 +62,15 @@ function Get-BaseVersion([string] $Raw) {
     return "$($m.Groups[1].Value).$($m.Groups[2].Value).$($m.Groups[3].Value)"
 }
 
+# The semver prerelease label of a version, e.g. "1.18.7.50-preview" -> "preview", "1.18.7.50" -> $null.
+# Anything after the first '-' counts, so build metadata ("+abc") is left alone.
+function Get-PrereleaseLabel([string] $Raw) {
+    if ([string]::IsNullOrWhiteSpace($Raw)) { return $null }
+    $m = [regex]::Match($Raw.Trim(), '-(?<label>[^+]+)')
+    if (-not $m.Success) { return $null }
+    return $m.Groups['label'].Value
+}
+
 if ($Version) {
     # Explicit mode: check exactly this tag (the publish workflow's pre-flight guard / manual backfill).
     $releaseTag = $Version
@@ -64,10 +78,12 @@ if ($Version) {
     if (-not $releaseBase) {
         throw "Could not parse a 3-part version from -Version '$releaseTag'."
     }
-    Write-Host "Checking specific version: tag '$releaseTag' -> base version '$releaseBase'"
+    # There is no release to inspect in this mode, so the channel comes from the version string itself.
+    $channel = if (Get-PrereleaseLabel $releaseTag) { 'preview' } else { 'stable' }
+    Write-Host "Checking specific version: tag '$releaseTag' -> base version '$releaseBase' ($channel)"
 }
 else {
-    Write-Host "Resolving latest release of $CSdkRepo ..."
+    Write-Host "Resolving newest release of $CSdkRepo (prereleases included) ..."
 
     $ghHeaders = @{
         'Accept'               = 'application/vnd.github+json'
@@ -76,25 +92,54 @@ else {
     }
     if ($GithubToken) { $ghHeaders['Authorization'] = "Bearer $GithubToken" }
 
-    $latestRelease = Invoke-RestMethod -Method Get -Headers $ghHeaders `
-        -Uri "https://api.github.com/repos/$CSdkRepo/releases/latest"
+    # NOT /releases/latest: that endpoint excludes prereleases by definition, and we want to build and ship
+    # every csdk prerelease. Take the whole (newest-first) list, drop drafts, and pick the highest version.
+    # No @() around the call: Invoke-RestMethod hands back the JSON array as a single object, and wrapping it
+    # would make a one-element array of an array. Piping it enumerates the releases properly.
+    $releases = Invoke-RestMethod -Method Get -Headers $ghHeaders `
+        -Uri "https://api.github.com/repos/$CSdkRepo/releases?per_page=50"
 
-    $releaseTag = $latestRelease.tag_name
-    $releaseBase = Get-BaseVersion $releaseTag
-    if (-not $releaseBase) {
-        throw "Could not parse a 3-part version from latest release tag '$releaseTag'."
+    # Non-version tags (csdk has a rolling 'nightly' release) fall out here, since Get-BaseVersion returns null.
+    $candidates = @($releases |
+        Where-Object { -not $_.draft } |
+        ForEach-Object {
+            $b = Get-BaseVersion $_.tag_name
+            if ($b) { [pscustomobject]@{ Tag = $_.tag_name; Base = $b; Prerelease = [bool]$_.prerelease } }
+        })
+    if ($candidates.Count -eq 0) {
+        throw "No $CSdkRepo release has a version-like tag. Nothing to resolve."
     }
-    Write-Host "Latest $CSdkRepo release: tag '$releaseTag' -> base version '$releaseBase'"
+
+    # Highest base version wins. On a tie (csdk cut both '1.19.0-rc1' and '1.19.0'), the stable one wins,
+    # so a promoted release is seen as stable rather than sticking on its own prerelease.
+    $latest = $candidates |
+        Sort-Object -Property @{ Expression = { [version]$_.Base }; Descending = $true },
+                              @{ Expression = { $_.Prerelease }; Descending = $false } |
+        Select-Object -First 1
+
+    $releaseTag = $latest.Tag
+    $releaseBase = $latest.Base
+    $channel = if ($latest.Prerelease) { 'preview' } else { 'stable' }
+    Write-Host "Newest $CSdkRepo release: tag '$releaseTag' -> base version '$releaseBase' ($channel)"
 }
 
 Write-Host "Resolving published versions of $NugetPackageId on nuget.org ..."
 
 # nuget flatcontainer index is lowercase by convention.
 $pkgLower = $NugetPackageId.ToLowerInvariant()
-$publishedBases = @()
+# Keys are "<base>|<channel>", e.g. "1.18.2|stable" or "1.18.7|preview". The run number (4th part) is
+# deliberately dropped: it identifies a build of a csdk version, not a different csdk version.
+$publishedKeys = @()
 try {
     $index = Invoke-RestMethod -Method Get -Uri "https://api.nuget.org/v3-flatcontainer/$pkgLower/index.json"
-    $publishedBases = @($index.versions | ForEach-Object { Get-BaseVersion $_ } | Where-Object { $_ } | Sort-Object -Unique)
+    $publishedKeys = @($index.versions |
+        ForEach-Object {
+            $b = Get-BaseVersion $_
+            if ($b) {
+                $c = if (Get-PrereleaseLabel $_) { 'preview' } else { 'stable' }
+                "$b|$c"
+            }
+        } | Sort-Object -Unique)
 }
 catch {
     # A 404 means the package has never been published; treat as "nothing published yet".
@@ -106,21 +151,22 @@ catch {
     }
 }
 
-Write-Host "Published base versions on nuget.org: $([string]::Join(', ', $publishedBases))"
+Write-Host "Published base versions on nuget.org: $([string]::Join(', ', $publishedKeys))"
 
-$alreadyPublished = $publishedBases -contains $releaseBase
+$releaseKey = "$releaseBase|$channel"
+$alreadyPublished = $publishedKeys -contains $releaseKey
 $shouldPublish = -not $alreadyPublished
 
 Write-Host ''
 if ($alreadyPublished -and $Force) {
-    Write-Host "Release '$releaseBase' is already published, but -Force was set: publishing anyway (new run number)."
+    Write-Host "Release '$releaseBase' ($channel) is already published, but -Force was set: publishing anyway (new run number)."
     $shouldPublish = $true
 }
 elseif ($alreadyPublished) {
-    Write-Host "Release '$releaseBase' is already published. Nothing to do."
+    Write-Host "Release '$releaseBase' ($channel) is already published. Nothing to do."
 }
 else {
-    Write-Host "Release '$releaseBase' is NOT yet published."
+    Write-Host "Release '$releaseBase' ($channel) is NOT yet published."
     if ($DryRun) {
         Write-Host "[DryRun] Would publish version '$releaseTag' (passing tag to the build workflow)."
     }
@@ -132,6 +178,7 @@ else {
 Write-GhOutput 'shouldPublish' ($shouldPublish.ToString().ToLowerInvariant())
 Write-GhOutput 'version' $releaseTag
 Write-GhOutput 'baseVersion' $releaseBase
+Write-GhOutput 'channel' $channel
 
 # Exit 0 always: "nothing to publish" is a normal, successful outcome.
 exit 0


### PR DESCRIPTION
publish csdk prereleases as -preview, and build+gate nightly even when nothing ships