### PR TITLE
updates to build to pick up sdk releases sooner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  # The managed SDK's native dependency tracks ziti-sdk-c, and a csdk struct change breaks the interop layer.
+  # Letting dependabot raise the bump means managed-tests runs the ABI check (NativeLayoutChecker reads the
+  # layout live from the referenced native) against every new native, so a break shows up as a red PR rather
+  # than a surprise at release time.
+  #
+  # Dependabot offers a prerelease version only when the current requirement is already a prerelease, so this
+  # tracks -preview natives while the pin carries a label, and stable ones once it does not.
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/native-nuget-publish.yml
+++ b/.github/workflows/native-nuget-publish.yml
@@ -346,6 +346,30 @@ jobs:
           if-no-files-found: error
 
   # ---- Pre-publish gates ----------------------------------------------------------------------------
+  # Hard gate: the managed interop structs must still match the freshly packed native. NativeLayoutChecker
+  # reads the per-field layout out of the native's own z4d_layout_report() and compares it to the managed
+  # structs, so a ziti-sdk-c model change is caught here rather than after the package is on nuget.org --
+  # permanently. The smoke and traffic gates cannot see this: a moved struct field still loads and still
+  # carries traffic, because the idiomatic path marshals only handles and primitives.
+  abi-test:
+    needs: [create-nuget-package]
+    runs-on: windows-2022
+    env:
+      resolvedversion: ${{ needs.create-nuget-package.outputs.resolvedversion }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+      - name: Download packed nupkg
+        uses: actions/download-artifact@v4
+        with:
+          name: OpenZiti.NET.native.${{ env.resolvedversion }}.nupkg
+          path: ${{ github.workspace }}/artifacts
+      - name: Managed ABI tests against the packed native
+        shell: pwsh
+        run: ./scripts/run-managed-tests.ps1 -PackageDir "${{ github.workspace }}/artifacts" -PackageVersion "${{ env.resolvedversion }}"
+
   # Hard gate: prove the freshly packed native lib LOADS and is callable on every natively-runnable RID.
   # linux-arm, linux-arm64, and ios-arm64 are cross-compiled and cannot run on hosted runners, so they are
   # NOT smoke-tested here. That is a known coverage gap (logged below), not a silent skip.
@@ -427,7 +451,7 @@ jobs:
   # transient plumbing for the managed SDK, so it gets a lightweight git tag (to find the commit behind a nuget
   # version) but NO GitHub Release. Releases live on the idiomatic OpenZiti.NET package.
   publish:
-    needs: [resolve, create-nuget-package, smoke-test, e2e-test]
+    needs: [resolve, create-nuget-package, abi-test, smoke-test, e2e-test]
     # Push only from the canonical repo, never on a dry run, and only when this csdk version + channel is not
     # already on nuget.org. The build and both gates above ran regardless; this is the only job that cares
     # whether there is something new to ship.
@@ -483,7 +507,7 @@ jobs:
   # JSON dump) and a concise failure line plus the run URL instead. Depends on the hard-gate jobs only, so the
   # soft e2e does not trigger it, and a clean "already published" skip is not a failure so it stays quiet.
   notify-failure:
-    needs: [resolve, native-matrix-build, create-nuget-package, smoke-test, publish]
+    needs: [resolve, native-matrix-build, create-nuget-package, abi-test, smoke-test, publish]
     if: ${{ failure() && github.repository_owner == 'openziti' }}
     runs-on: ubuntu-latest
     name: POST Webhook (failure)

--- a/OpenZiti.NET.Tests/OpenZiti.NET.Tests.csproj
+++ b/OpenZiti.NET.Tests/OpenZiti.NET.Tests.csproj
@@ -39,7 +39,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenZiti.NET.native" Version="1.18.2.49" />
+    <!--
+      Normally absent: the native arrives transitively from OpenZiti.NET, whose PackageReference is the single
+      pin (and the one dependabot maintains). The native publish gate sets ZitiNativeVersion to the version it
+      just packed, and this direct reference then wins over the transitive one, so the ABI tests measure the
+      fresh native instead of the pinned one. scripts/run-managed-tests.ps1 -PackageDir/-PackageVersion.
+    -->
+    <PackageReference Include="OpenZiti.NET.native" Version="$(ZitiNativeVersion)"
+                      Condition="'$(ZitiNativeVersion)' != ''" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenZiti.NET/OpenZiti.NET.csproj
+++ b/OpenZiti.NET/OpenZiti.NET.csproj
@@ -54,7 +54,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2" />
         <PackageReference Include="NLog" Version="6.0.7" />
-        <PackageReference Include="OpenZiti.NET.native" Version="1.18.2.49" />
+        <PackageReference Include="OpenZiti.NET.native" Version="1.18.7.289-preview" />
         <PackageReference Include="System.Memory" Version="4.6.3" />
         <PackageReference Include="System.Text.Json" Version="10.0.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/OpenZiti.NET/OpenZiti.NET.nuspec
+++ b/OpenZiti.NET/OpenZiti.NET.nuspec
@@ -22,7 +22,7 @@
         <dependency id="Microsoft.Extensions.Logging" version="10.0.2" exclude="Build,Analyzers" xmlns="" />
         <dependency id="Newtonsoft.Json" version="13.0.4" exclude="Build,Analyzers" xmlns="" />
         <dependency id="NLog" version="6.0.7" exclude="Build,Analyzers" xmlns="" />
-        <dependency id="OpenZiti.NET.native" version="1.18.2.49" exclude="Build,Analyzers" xmlns="" />
+        <dependency id="OpenZiti.NET.native" version="1.18.7.289-preview" exclude="Build,Analyzers" xmlns="" />
         <dependency id="System.Memory" version="4.6.3" exclude="Build,Analyzers" xmlns="" />
         <dependency id="System.Text.Json" version="10.0.2" exclude="Build,Analyzers" xmlns="" />
       </group>

--- a/native/e2e-app/e2e-app.csproj
+++ b/native/e2e-app/e2e-app.csproj
@@ -11,8 +11,12 @@
     <RootNamespace>ZitiE2e</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
-    <!-- which native build to test; CI passes the fresh one -->
-    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.2.49</ZitiNativeVersion>
+    <!--
+      Which native to run against. CI passes the fresh one. This project P/Invokes the native directly with no
+      reference to OpenZiti.NET, so it needs its own default; keep it matching the pin in OpenZiti.NET.csproj
+      or a local run tests the app against one native and the e2e against another.
+    -->
+    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.7.289-preview</ZitiNativeVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/native/e2e/E2ETest.csproj
+++ b/native/e2e/E2ETest.csproj
@@ -6,15 +6,20 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <!-- which native build to test; CI passes the fresh one -->
-    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.2.49</ZitiNativeVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
-    <PackageReference Include="OpenZiti.NET.native" Version="$(ZitiNativeVersion)" />
+    <!--
+      Normally absent: OpenZiti.NET carries the native pin and this project gets it transitively through the
+      ProjectReference below. The native publish gate sets ZitiNativeVersion to the version it just packed,
+      and this direct reference then wins. A hardcoded fallback here would fight that pin as a nuget
+      downgrade (NU1605) every time the pin moved ahead of it.
+    -->
+    <PackageReference Include="OpenZiti.NET.native" Version="$(ZitiNativeVersion)"
+                      Condition="'$(ZitiNativeVersion)' != ''" />
   </ItemGroup>
 
   <ItemGroup>

--- a/native/smoke-test/SmokeTest.csproj
+++ b/native/smoke-test/SmokeTest.csproj
@@ -19,7 +19,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <!-- Fallback only for ad-hoc local runs; CI always passes -p:ZitiNativeVersion=... -->
-    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.2.49</ZitiNativeVersion>
+    <ZitiNativeVersion Condition="'$(ZitiNativeVersion)' == ''">1.18.7.289-preview</ZitiNativeVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/keepalive.sh
+++ b/scripts/keepalive.sh
@@ -10,7 +10,11 @@
 # clock and the heartbeat only fires when the repo is genuinely quiet. A committed file change is used on purpose:
 # empty commits and tag pushes don't reliably count as activity.
 #
-# Safe to run locally; override the threshold with KEEPALIVE_MAX_AGE_DAYS.
+# The commit is written through the GitHub contents API rather than git push, because main requires verified
+# signatures. Needs gh with a token carrying contents:write; override the target with KEEPALIVE_BRANCH.
+#
+# Override the threshold with KEEPALIVE_MAX_AGE_DAYS. Running it with no args on a repo that is not yet stale
+# exits before touching anything, which makes it safe to try by hand.
 #
 # Usage:
 #   ./scripts/keepalive.sh                        # heartbeat if the repo is going stale
@@ -48,17 +52,36 @@ else
     commit_msg="keepalive: repo heartbeat (reset 60-day inactivity clock)"
 fi
 
-echo "$entry" >> "$log_file"
-git add "$log_file"
+# main requires verified signatures, and a runner has no signing key, so the write goes through the GitHub
+# contents API instead of git push: commits created that way are signed with GitHub's own web-flow key and
+# satisfy the rule. gh supplies auth from GH_TOKEN.
+repo="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+branch="${KEEPALIVE_BRANCH:-main}"
 
-if git diff --cached --quiet; then
-    echo "keepalive: nothing to commit"
-    exit 0
+# The blob sha of the file as it exists on the branch, empty when the log has never been written.
+existing_sha="$(gh api "repos/${repo}/contents/${log_file}?ref=${branch}" --jq .sha 2>/dev/null || true)"
+
+if [ -n "$existing_sha" ]; then
+    existing_content="$(gh api "repos/${repo}/contents/${log_file}?ref=${branch}" --jq .content | tr -d '\n' | base64 -d)"
+    new_content="${existing_content}${entry}"$'\n'
+else
+    new_content="${entry}"$'\n'
 fi
 
-# Commit as the Actions bot without persisting identity into repo config.
-git \
-    -c user.name="github-actions[bot]" \
-    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-    commit -m "$commit_msg"
-git push
+encoded="$(printf '%s' "$new_content" | base64 -w0)"
+
+echo "keepalive: committing to ${repo}@${branch}: ${commit_msg}"
+if [ -n "$existing_sha" ]; then
+    gh api -X PUT "repos/${repo}/contents/${log_file}" \
+        -f message="$commit_msg" \
+        -f content="$encoded" \
+        -f branch="$branch" \
+        -f sha="$existing_sha" \
+        --jq '.commit.sha'
+else
+    gh api -X PUT "repos/${repo}/contents/${log_file}" \
+        -f message="$commit_msg" \
+        -f content="$encoded" \
+        -f branch="$branch" \
+        --jq '.commit.sha'
+fi

--- a/scripts/keepalive.sh
+++ b/scripts/keepalive.sh
@@ -53,18 +53,22 @@ else
 fi
 
 # main requires verified signatures, and a runner has no signing key, so the write goes through the GitHub
-# contents API instead of git push: commits created that way are signed with GitHub's own web-flow key and
-# satisfy the rule. gh supplies auth from GH_TOKEN.
+# contents API instead of git push. GitHub signs those commits with its web-flow key when the caller is an app
+# installation token, which the Actions GITHUB_TOKEN is. Running this by hand with a personal access token
+# produces an UNSIGNED commit, so a local run proves the file write but not the signature.
 repo="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 branch="${KEEPALIVE_BRANCH:-main}"
 
-# The blob sha of the file as it exists on the branch, empty when the log has never been written.
-existing_sha="$(gh api "repos/${repo}/contents/${log_file}?ref=${branch}" --jq .sha 2>/dev/null || true)"
-
-if [ -n "$existing_sha" ]; then
-    existing_content="$(gh api "repos/${repo}/contents/${log_file}?ref=${branch}" --jq .content | tr -d '\n' | base64 -d)"
+# Read the file as it exists on the branch. A 404 means the log has never been written, which is normal on a
+# fresh repo, so fall through to creating it. Note gh prints its error BODY to stdout, so the response is only
+# parsed when the call actually succeeded -- otherwise the error json gets mistaken for content.
+if existing_json="$(gh api "repos/${repo}/contents/${log_file}?ref=${branch}" 2>/dev/null)"; then
+    existing_sha="$(printf '%s' "$existing_json" | jq -r '.sha // empty')"
+    existing_content="$(printf '%s' "$existing_json" | jq -r '.content // empty' | tr -d '\n' | base64 -d)"
     new_content="${existing_content}${entry}"$'\n'
 else
+    echo "keepalive: ${log_file} not on ${branch} yet; creating it"
+    existing_sha=""
     new_content="${entry}"$'\n'
 fi
 

--- a/scripts/run-managed-tests.ps1
+++ b/scripts/run-managed-tests.ps1
@@ -12,26 +12,93 @@
     on every PR): DataTests.TestWeatherAsync and everything in the native/e2e project (CallbackTrafficTest,
     ProxyBridgeTest, IdiomaticTrafficTest).
 
+    Two modes, matching run-e2e-test.ps1:
+      - No arguments: test against the native pinned in OpenZiti.NET.csproj, restored from nuget.org. This is
+        the PR check.
+      - -PackageDir/-PackageVersion: test against a freshly packed nupkg. This is the native publish gate, and
+        it is what catches a ziti-sdk-c struct change BEFORE the native reaches nuget.org. A csdk change that
+        still compiles can move a field, which the smoke and traffic gates would not notice.
+
     Runnable locally to reproduce CI: ./scripts/run-managed-tests.ps1
 
 .PARAMETER Configuration
     Build configuration. Defaults to Release.
+
+.PARAMETER PackageDir
+    Folder holding a freshly packed OpenZiti.NET.native nupkg, added as a nuget source.
+
+.PARAMETER PackageVersion
+    Version of that packed package. Pins OpenZiti.NET.Tests to it, overriding the transitive pinned native.
+
+.EXAMPLE
+    ./run-managed-tests.ps1
+
+.EXAMPLE
+    ./run-managed-tests.ps1 -PackageDir ./artifacts -PackageVersion 1.18.7.289-preview
 #>
 [CmdletBinding()]
 param(
-    [string] $Configuration = 'Release'
+    [string] $Configuration = 'Release',
+    [string] $PackageDir = '',
+    [string] $PackageVersion = ''
 )
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 
+if ([string]::IsNullOrWhiteSpace($PackageDir) -ne [string]::IsNullOrWhiteSpace($PackageVersion)) {
+    throw "-PackageDir and -PackageVersion go together: pass both or neither."
+}
+
+# Sort key for an OpenZiti.NET.native version: the 4-part numeric prefix, then unlabelled above -preview.
+function Get-NativeVersionKey([string] $Raw) {
+    $m = [regex]::Match($Raw, '^(?<num>\d+(\.\d+){0,3})(-(?<label>.+))?$')
+    if (-not $m.Success) { throw "cannot parse native version '$Raw'." }
+    return [pscustomobject]@{
+        Number     = [version] $m.Groups['num'].Value
+        Prerelease = $m.Groups['label'].Success
+    }
+}
+
+if ($PackageVersion) {
+    # OpenZiti.NET pins the native the SDK ships against; the tests reference the packed one directly to
+    # override it. NuGet treats a lower direct version as a downgrade (NU1605) and fails the restore, so
+    # catch it here with an explanation rather than letting it surface as a wall of restore errors.
+    $sdkProj = Join-Path $repoRoot 'OpenZiti.NET/OpenZiti.NET.csproj'
+    $pinMatch = [regex]::Match((Get-Content $sdkProj -Raw),
+        '<PackageReference\s+Include="OpenZiti\.NET\.native"\s+Version="(?<v>[^"]+)"')
+    if ($pinMatch.Success) {
+        $pinned = $pinMatch.Groups['v'].Value
+        $a = Get-NativeVersionKey $PackageVersion
+        $b = Get-NativeVersionKey $pinned
+        $older = ($a.Number -lt $b.Number) -or
+                 ($a.Number -eq $b.Number -and $a.Prerelease -and -not $b.Prerelease)
+        if ($older) {
+            throw ("cannot gate native ${PackageVersion}: OpenZiti.NET pins ${pinned}, and nuget rejects the " +
+                   "downgrade (NU1605). Gate a version at or above the pin, or move the pin first.")
+        }
+    }
+}
+
+# With a PackageDir, add the local source and pin the packed version; the test project's conditional
+# PackageReference then takes precedence over the native it would otherwise inherit from OpenZiti.NET.
+$nativeProps = @()
+if ($PackageVersion) { $nativeProps += "-p:ZitiNativeVersion=$PackageVersion" }
+if ($PackageDir) {
+    $source = (Resolve-Path $PackageDir).Path
+    $nativeProps += "-p:RestoreAdditionalProjectSources=$source"
+    Write-Host "Testing freshly packed native $PackageVersion from $source"
+} else {
+    Write-Host "Testing the published native pinned in the csprojs (restored from nuget.org)"
+}
+
 Write-Host "Building Ziti.NuGet.sln ($Configuration) ..."
-dotnet build (Join-Path $repoRoot 'Ziti.NuGet.sln') -c $Configuration --nologo
+dotnet build (Join-Path $repoRoot 'Ziti.NuGet.sln') -c $Configuration --nologo @nativeProps
 if ($LASTEXITCODE -ne 0) { throw "build failed ($LASTEXITCODE)" }
 
 Write-Host "Running managed ABI tests ..."
 dotnet test (Join-Path $repoRoot 'OpenZiti.NET.Tests/OpenZiti.NET.Tests.csproj') `
-    -c $Configuration --no-build --nologo `
+    -c $Configuration --no-build --nologo @nativeProps `
     --filter "FullyQualifiedName~NativeCodeValueChecker|FullyQualifiedName~NativeLayoutChecker"
 if ($LASTEXITCODE -ne 0) { throw "managed tests failed ($LASTEXITCODE)" }
 


### PR DESCRIPTION
gate the native on the abi check, sign the keepalive commit, let dependabot track the native